### PR TITLE
Use node binary defined by user environment

### DIFF
--- a/mkcjs.js
+++ b/mkcjs.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 "use strict";
 if (process.argv.length<3){
 	process.stdout.write("mkcjs OUT [MODULES]\n");
@@ -27,5 +27,5 @@ function writeModule(n){
 	src.pipe(out, {end: false});
 }
 var plate = fs.createReadStream(path.resolve(__dirname, "plate.js"));
-plate.on("end", function(){writeModule(3)});
+plate.on("end", function(){writeModule(3);});
 plate.pipe(out, {end: false});


### PR DESCRIPTION
Hardcoding the node binary location can cause issues
The default install location of node is now `/usr/local/bin/node`
Using env, we can be a bit more agnostic

Minor:
Added in a missing semicolon that lint was crying over
Added newline at end of file
